### PR TITLE
Updated the Paper 1.18.1 to the latest version.

### DIFF
--- a/install
+++ b/install
@@ -517,7 +517,7 @@ if [[ $? == 0 ]]; then
       # https://papermc.io/downloads
       flavor="Paper"
       if [[ $mcver == "1.18.1" ]]; then
-        url="https://papermc.io/api/v2/projects/paper/versions/1.18.1/builds/181/downloads/paper-1.18.1-181.jar"
+        url="https://papermc.io/api/v2/projects/paper/versions/1.18.1/builds/207/downloads/paper-1.18.1-207.jar"
       elif [[ $mcver == "1.18" ]]; then
         url="https://papermc.io/api/v2/projects/paper/versions/1.18/builds/66/downloads/paper-1.18-66.jar"
       elif [[ $mcver == "1.17.1" ]]; then


### PR DESCRIPTION
This is the latest version of paper. https://papermc.io/api/v2/projects/paper/versions/1.18.1/builds/207/downloads/paper-1.18.1-207.jar is the link. Robbie please keep updating these links.  It is causing issues in the code.