### PR TITLE
Add Patreon sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+patreon: pinecraft


### PR DESCRIPTION
Things added/changed:

- Add Patreon sponsor button.
  - You'll have to enable the sponsorship button on the repository settings. For more information, see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository#displaying-a-sponsor-button-in-your-repository
