### PR TITLE
Update Minecraft wiki references

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The installer will setup a "Normal" difficulty server and allow you to select be
 
 The installer attempts to detect things like how much RAM you have (and available), and adjusts the server settings based on what it finds.
 
-**Looking For Help?** Pinecraft Installer *installs* Minecraft Java servers. If your question has to do with something other than *installing* a Minecraft server with Pinecraft Installer, the question likely is not for us. Questions surrounding gameplay, how to use a Minecraft server, etc., should be directed to [the Minecraft documentation](https://minecraft.fandom.com/wiki/Tutorials/Setting_up_a_server). Once your Minecraft server is installed, Pinecraft's job is done.
+**Looking For Help?** Pinecraft Installer *installs* Minecraft Java servers. If your question has to do with something other than *installing* a Minecraft server with Pinecraft Installer, the question likely is not for us. Questions surrounding gameplay, how to use a Minecraft server, etc., should be directed to [The Minecraft Wiki](https://minecraft.wiki/w/Tutorials/Setting_up_a_server). Once your Minecraft server is installed, Pinecraft's job is done.
 
 ## Monitor Your Pinecraft Server
 
@@ -392,7 +392,7 @@ Give your Minecraft server a try before you start changing the config. It's very
 
 You'll find your config file here: ~/minecraft/server.properties
 
-Mojang Documentation: https://minecraft.gamepedia.com/Server.properties#Java_Edition_3
+Minecraft Wiki: https://minecraft.wiki/w/Server.properties#Keys
 
 
 Frequently Asked Questions
@@ -406,7 +406,7 @@ That said, we get some questions regularly, and we're here to help if we can, so
 **First, here are some helpful links:**
 
 Modify server.properties, the main config file for your server's settings
-https://minecraft.gamepedia.com/Server.properties#Java_Edition_3
+https://minecraft.wiki/w/Server.properties#Keys
 
 **Find Plugins for Spigot / Paper / Fabric**
 https://www.spigotmc.org/resources/categories/spigot.4/

--- a/assets/psi/Minecraft-RCON/index.php
+++ b/assets/psi/Minecraft-RCON/index.php
@@ -23,7 +23,7 @@
         <div class="panel-heading">
           <h3 class="panel-title pull-left"><span class="glyphicon glyphicon-console"></span> Console</h3>
           <div class="btn-group btn-group-xs pull-right">
-            <a class="btn btn-default" href="http://minecraft.gamepedia.com/Commands" target="_blank"><span class="glyphicon glyphicon-question-sign"></span><span class="hidden-xs"> Commands</span></a>
+            <a class="btn btn-default" href="http://minecraft.wiki/w/Commands" target="_blank"><span class="glyphicon glyphicon-question-sign"></span><span class="hidden-xs"> Commands</span></a>
             <a class="btn btn-default" href="http://www.minecraftinfo.com/idlist.htm" target="_blank"><span class="glyphicon glyphicon-info-sign"></span><span class="hidden-xs"> Items IDs</span></a>
           </div>
         </div>


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all references accordingly.

I also renamed references to the wiki as documentation as just the wiki as no wiki, as of late 2021, is considered official documentation.